### PR TITLE
fix: pnpmバージョン指定の重複を解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
package.jsonのpackageManagerフィールドと競合するため
deploy.ymlのversion指定を削除。